### PR TITLE
Simple addition of coordinates and velocities to player log

### DIFF
--- a/Assets/Scripts/TrainingAgent.cs
+++ b/Assets/Scripts/TrainingAgent.cs
@@ -84,6 +84,7 @@ public class TrainingAgent : Agent, IPrefab
         sensor.AddObservation(localVel);
         Vector3 localPos = transform.position;
         sensor.AddObservation(localPos);
+        Debug.Log("Health:" + health + "\nVelocity: " + localVel + "\nPosition:" + localPos);
     }
 
     public override void OnActionReceived(ActionBuffers action)
@@ -128,6 +129,7 @@ public class TrainingAgent : Agent, IPrefab
             AddReward(updateAmount);
         }
         _currentScore = GetCumulativeReward();
+        Debug.Log("Current score is: " + _currentScore);
         if (health > _maxHealth)
         {
             health = _maxHealth;


### PR DESCRIPTION
### Proposed change

In this update, coordinate and velocity information are logged directly in the player log, allowing coordinate and trajectory data to be recorded during play. This has been previously used in experiments in a bespoke build, so this pull request is simply to bring the current version of Animal-AI up to speed. I expect that this method of logging player data will be deprecated in favour of a cleaner and more robust approach in the future.

### Useful links (Github issues, ML-Agents forum threads etc.)

Related to issue #28 but does not resolve it.

### Types of change(s)

- [ ] Bug fix
- [X ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [X ] Added tests that prove my fix is effective or that my feature works -- reproducible through an instance of AAI in play mode with a player log folder path provided.
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments

None.

### Screenshots (if any)

None.
```
