### PR TITLE
Add multi-arena episodes

### DIFF
--- a/Assets/Scripts/AAI3EnvironmentManager.cs
+++ b/Assets/Scripts/AAI3EnvironmentManager.cs
@@ -214,7 +214,7 @@ public class AAI3EnvironmentManager : MonoBehaviour
 		OnArenaChanged?.Invoke(currentArenaIndex, totalArenas);
 	}
 
-	public int getMaxArenaID()
+	public int getArenaCount()
 	{
 		return _arenasConfigurations.configurations.Count;
 	}

--- a/Assets/Scripts/AAI3EnvironmentManager.cs
+++ b/Assets/Scripts/AAI3EnvironmentManager.cs
@@ -214,11 +214,6 @@ public class AAI3EnvironmentManager : MonoBehaviour
 		OnArenaChanged?.Invoke(currentArenaIndex, totalArenas);
 	}
 
-	public int getArenaCount()
-	{
-		return _arenasConfigurations.configurations.Count;
-	}
-
 	public bool GetRandomizeArenasStatus()
 	{
 		return _arenasConfigurations.randomizeArenas;
@@ -314,9 +309,14 @@ public class AAI3EnvironmentManager : MonoBehaviour
 
 	#region Configuration Management Methods
 
-	public bool GetConfiguration(int arenaID, out ArenaConfiguration arenaConfiguration)
+	public ArenaConfiguration GetConfiguration(int arenaID)
 	{
-		return _arenasConfigurations.configurations.TryGetValue(arenaID, out arenaConfiguration);
+		ArenaConfiguration returnConfiguration;
+		if (!_arenasConfigurations.configurations.TryGetValue(arenaID, out returnConfiguration))
+		{
+			throw new KeyNotFoundException($"Tried to load arena {arenaID} but it did not exist");
+		}
+		return returnConfiguration;
 	}
 
 	public void AddConfiguration(int arenaID, ArenaConfiguration arenaConfiguration)

--- a/Assets/Scripts/ArenasParameters.cs
+++ b/Assets/Scripts/ArenasParameters.cs
@@ -141,6 +141,7 @@ namespace ArenasParameters
 		public bool toUpdate = false;
 		public string protoString = "";
 		public int randomSeed = 0;
+		public bool mergeNextArena = false;
 
 		public ArenaConfiguration() { }
 
@@ -175,6 +176,7 @@ namespace ArenasParameters
 			toUpdate = true;
 			protoString = yamlArena.ToString();
 			randomSeed = yamlArena.randomSeed;
+			this.mergeNextArena = yamlArena.mergeNextArena;
 		}
 
 		/// <summary>

--- a/Assets/Scripts/YAMLclasses.cs
+++ b/Assets/Scripts/YAMLclasses.cs
@@ -51,6 +51,7 @@ namespace YAMLDefs
 
 		public List<int> blackouts { get; set; } = new List<int>();
 		public int randomSeed { get; set; } = 0;
+		public bool mergeNextArena { get; set; } = false;
 	}
 
 	/// <summary>


### PR DESCRIPTION
Adds the feature of multi-arena episodes, by looking for the mergeNextArena parameter in an arena's yaml. When a good (not timeout or death) episode end is reached TrainingAgent checks TrainingArena to see if it should end the episode or merge the next arena. If the latter it calls the new TrainingArena function loadNextArena.

- **Discarded Alternative:** Just call ResetArena() since it does basically the same thing. This would be more complicated to implement in the situation where arenas are being randomly cycled. Also I think the semantics of ResetArena in AAI are already a bit complicated and I didn't want to further the problem.

- **Discarded alternative:** Add a `completeArena` function to TrainingArena with a boolean for whether the episode was successful or not. **Benefit:** The TrainingAgent doesn't have to care about whether to call EndEpisode or rotate the arenas **Drawback:** Would have to pass control of showing notifications to TrainingArena, as TrainingAgent doesn't know whether the completion of an arena means a notification should be shown (episode end) or not (arena has been merged)

### Proposed change(s)

Adds multi arena episode support

#### Additional changes:
- Merge the functions TryLoadArenaConfiguration, ApplyNewArenaConfiguration, CleanupRewards, NotifyArenaChange into one function (having three separate functions when they're always called in sequence increases the chance one is missed out)
- If the arena is randomised, use the ChooseRandomArenaID function on the first call (I think we can probably get rid of that code branch somehow but I wasn't brave enough to do it this time)
- Rename getMaxArenaID to getArenaCount (This function returns the count. We expect arenas to be indexed from 0, so would expect the max arena ID to be the count-1)
- Rename DetermineNextArenaID to SetNextArenaID to emphasise the function's side effect

### Useful links (Github issues, ML-Agents forum threads etc.)

- Ticket: https://www.notion.so/Multi-Arena-Episodes-7edc1ee064034193967f46bc12c75913?pm=c
- Documentation change: https://github.com/Kinds-of-Intelligence-CFI/animal-ai/pull/51

### Types of change(s)

- [ ] Bug fix
- [X] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [To be added in new package] Added tests that prove my fix is effective or that my feature works
- [Will do in update to https://github.com/Kinds-of-Intelligence-CFI/animal-ai/pull/51] Updated the changelog (if applicable)
- [X] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Testing

- Tests of a merged arena + failure cases in E2E tests (I'll push these to a new repo)
- Manually test error case of putting mergeNextArena in the final arena (The error does get swallowed though - https://www.notion.so/Don-t-swallow-Unity-errors-9c1c84c1c51c4165b0d5d46e3d764c7c?pvs=4)
- Manually test exclusion of merged arenas when randomiseArenas is set to true (Add a debug log in TrainingArena.cs that prints out validArenaIDs and confirm one is excluded)
- Train stablebaselines PPO on the arena from the E2E test and observe it learns without hitting an error