### PR TITLE
 Fixed 'passMark' Bug due to incorrect and inconsistent handling

### DIFF
--- a/Assets/Scripts/ArenasParameters.cs
+++ b/Assets/Scripts/ArenasParameters.cs
@@ -130,6 +130,7 @@ namespace ArenasParameters
         public string protoString = "";
         public int randomSeed = 0;
         public bool mergeNextArena = false;
+        public float passMark = 0;
 
         public ArenaConfiguration() { }
 
@@ -146,6 +147,7 @@ namespace ArenasParameters
         internal ArenaConfiguration(YAMLDefs.Arena yamlArena)
         {
             TimeLimit = yamlArena.timeLimit;
+            passMark = yamlArena.passMark;
             spawnables = new List<Spawnable>();
 
             foreach (YAMLDefs.Item item in yamlArena.items)
@@ -213,7 +215,6 @@ namespace ArenasParameters
                 }
             }
             CurrentArenaID = k;
-            yamlConfig.SetCurrentPassMark();
         }
 
         public void AddAdditionalArenas(YAMLDefs.ArenaConfig yamlArenaConfig)
@@ -222,7 +223,6 @@ namespace ArenasParameters
             {
                 int i = configurations.Count;
                 Add(i, arena);
-                arena.SetCurrentPassMark();
             }
         }
 

--- a/Assets/Scripts/TrainingAgent.cs
+++ b/Assets/Scripts/TrainingAgent.cs
@@ -687,10 +687,9 @@ public class TrainingAgent : Agent, IPrefab
         {
             _nextUpdateCompleteArena = false;
             float cumulativeReward = GetCumulativeReward();
-            Debug.Log($"Current pass mark: {Arena.CurrentPassMark}");
+            float passMark = _arena.ArenaConfig.passMark;
 
-            bool proceedToNext =
-                Arena.CurrentPassMark == 0 || cumulativeReward >= Arena.CurrentPassMark;
+            bool proceedToNext = passMark == 0 || cumulativeReward >= passMark;
 
             if (proceedToNext)
             {
@@ -734,6 +733,8 @@ public class TrainingAgent : Agent, IPrefab
 
     public override void OnEpisodeBegin()
     {
+        Debug.Log("Episode Begin");
+        Debug.Log("passMark from OnEpisodeBegin: " + _arena.ArenaConfig.passMark);
         _lastLoggedStep = -1;
 
         if (!_arena.IsFirstArenaReset)
@@ -746,7 +747,6 @@ public class TrainingAgent : Agent, IPrefab
         customEpisodeCount++;
 
         writer.Flush();
-        EpisodeDebugLogs();
 
         StopAllCoroutines();
         _previousScore = _currentScore;
@@ -757,14 +757,6 @@ public class TrainingAgent : Agent, IPrefab
         health = _maxHealth;
 
         SetFreezeDelay(GetFreezeDelay());
-    }
-
-    private void EpisodeDebugLogs()
-    {
-        Debug.Log("Episode Begin");
-        Debug.Log($"Value of showNotification: {showNotification}");
-        Debug.Log("Current Pass Mark: " + Arena.CurrentPassMark);
-        Debug.Log("Number of Goals Collected: " + numberOfGoalsCollected);
     }
 
     void OnCollisionEnter(Collision collision)

--- a/Assets/Scripts/TrainingArena.cs
+++ b/Assets/Scripts/TrainingArena.cs
@@ -143,6 +143,7 @@ public class TrainingArena : MonoBehaviour
         ArenaConfiguration newConfiguration = _environmentManager.GetConfiguration(arenaID);
 
         ApplyNewArenaConfiguration(newConfiguration);
+        Debug.Log($"Setting passMark to: {newConfiguration.passMark}");
 
         CleanupRewards();
 
@@ -156,6 +157,7 @@ public class TrainingArena : MonoBehaviour
             throw new InvalidOperationException("LoadNextArena called before first reset");
         }
         Debug.Log($"Loading next arena. Previous: {arenaID}, next: {arenaID + 1}");
+        Debug.Log($"Initialized Arena with passMark: {_arenaConfiguration.passMark}");
 
         CleanUpSpawnedObjects();
 
@@ -251,6 +253,13 @@ public class TrainingArena : MonoBehaviour
         }
 
         _arenaConfiguration = newConfiguration;
+        Debug.Log($"Setting passMark to: {newConfiguration.passMark}");
+        // Ensure passMark is set correctly
+        _arenaConfiguration.passMark = newConfiguration.passMark;
+
+        // Check passMark before proceeding
+        Debug.Log($"Post assignment, passMark is: {_arenaConfiguration.passMark}");
+
         var arenasConfigurations = _environmentManager.GetArenasConfigurations();
         if (arenasConfigurations != null)
         {
@@ -258,9 +267,7 @@ public class TrainingArena : MonoBehaviour
         }
         else
         {
-            Debug.LogError(
-                "ArenasConfigurations is not initialized in ApplyNewArenaConfiguration."
-            );
+            Debug.LogError("ArenasConfigurations is not initialized in ApplyNewArenaConfiguration.");
         }
 
         _arenaConfiguration.SetGameObject(prefabs.GetList());
@@ -275,6 +282,9 @@ public class TrainingArena : MonoBehaviour
         {
             Random.InitState(_arenaConfiguration.randomSeed);
         }
+
+        // Additional Debug to ensure passMark is correct before continuing
+        Debug.Log($"Final passMark in ApplyNewArenaConfiguration: {_arenaConfiguration.passMark}");
     }
 
     private void NotifyArenaChange()

--- a/Assets/Scripts/YAMLclasses.cs
+++ b/Assets/Scripts/YAMLclasses.cs
@@ -41,13 +41,6 @@ namespace YAMLDefs
         public int timeLimit { get; set; } = 0;
         public List<Item> items { get; set; } = new List<Item>();
         public float passMark { get; set; } = 0;
-        public static float CurrentPassMark { get; private set; }
-
-        public void SetCurrentPassMark()
-        {
-            CurrentPassMark = passMark;
-        }
-
         public List<int> blackouts { get; set; } = new List<int>();
         public int randomSeed { get; set; } = 0;
         public bool mergeNextArena { get; set; } = false;


### PR DESCRIPTION
### PR Description

The bug was apparent when multiple arenas were defined in the yaml configuration but some of them had incorrect/inconsistent passMark values assigned to them. For example, there are 3 arenas defined, with each 20, 50, 100 passMark values assigned to them. Upon play, the first arena had passMark value of 50, and second arena had a passMark of 20. Upon another play instance, the passMark for the first arena had the default 0 passMark value assigned, where it was explicitly assigned 100 in the yaml configuration. 

### Proposed change(s)

This PR refactors the handling of the `passMark` property across several classes to remove redundancy and simplify the codebase. Specifically, I removed unnecessary static properties and methods related to passMark and ensured that the value is correctly parsed from the YAML configuration and applied directly in the ArenaConfiguration class.

In the code, a redundant variable and getter method related to passMark parameter was removed to simply and improve code.


### Changes:

**Removed Redundant Static Logic:**

- The CurrentPassMark static property and associated SetCurrentPassMark method were removed from the Arena class, as they were unnecessary and caused duplication of logic.

**Direct Property Access:**

- The passMark property in the ArenaConfiguration class is now directly set from the YAML configuration and used without additional getter/setter methods.

**Updated Class Implementations:**

- YAMLDefs.cs: Simplified passMark handling by removing the static logic and using direct property assignment.
- ArenasParameters.cs: Removed duplicate logic and ensured that passMark is correctly stored and accessed within ArenaConfiguration.
- TrainingArena.cs: Cleaned up pass mark application logic, ensuring it is directly pulled from ArenaConfiguration.
- TrainingAgent.cs: Updated references to passMark to ensure it is used correctly during training.


### Useful links (Github issues, ML-Agents forum threads etc.)
- Fixed #38


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)


### Checklist

- [x] Added tests that prove my fix is effective or that my feature works
    - [x] Verified tests using existing tests and via Debug logs. 
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)


### Other comments

**Key tests carried out:** 
- Verified that the passMark is correctly parsed and applied from the YAML files in various test cases.
- Ensured that the agent behaves as expected when the passMark is set, including transitioning between arenas.
- Manually tested scenarios with different passMark values to ensure consistency and correctness.

This PR also significantly simplifies the handling of the passMark property, reducing the potential for bugs and making the code easier to maintain.

### Screenshots (if any)
```
