### PR TITLE
Fix blackouts feature error and add new unit tests

### DIFF
--- a/Assets/Scripts/Lights.cs
+++ b/Assets/Scripts/Lights.cs
@@ -3,16 +3,18 @@ using System.Collections;
 using System.Collections.Generic;
 
 /// <summary>
-/// Facilitates the management and retrieval of Fade components associated with a collection of GameObjects, black screens.
+/// Script for handling the lights in the environment (blackouts).
 /// </summary>
 namespace Lights
 {
     public class InfiniteEnumerator : IEnumerator<int>
     {
-        private int _initialValue;
-        private int _currentValue;
+        private readonly int _initialValue = 0;
+        private int _currentValue = 0;
 
-        public InfiniteEnumerator(int initialValue = 0)
+        public InfiniteEnumerator() { }
+
+        public InfiniteEnumerator(int initialValue)
         {
             _initialValue = initialValue;
             _currentValue = 0;
@@ -29,70 +31,112 @@ namespace Lights
             _currentValue = 0;
         }
 
-        public int Current => _currentValue;
+        public int Current
+        {
+            get { return _currentValue; }
+        }
 
-        object IEnumerator.Current => Current;
+        object IEnumerator.Current
+        {
+            get { return Current; }
+        }
 
-        public void Dispose() { }
+        void IDisposable.Dispose() { }
     }
-
     public class LightsSwitch
     {
-        private int _episodeLength;
+        private readonly int _episodeLength = 0;
         private bool _lightStatus = true;
-        private List<int> _blackouts;
-        private IEnumerator<int> _blackoutsEnum;
+        private readonly List<int> _blackouts = new List<int>();
+        private readonly IEnumerator<int> _blackoutsEnum;
         private int _nextFrameSwitch = -1;
 
-        public LightsSwitch(int episodeLength = 0, List<int> blackouts = null)
+        public LightsSwitch()
         {
-            if (episodeLength < 0)
-                throw new ArgumentException("Episode length cannot be negative.");
+            _blackoutsEnum = _blackouts.GetEnumerator();
+        }
 
-            _episodeLength = episodeLength;
-            _blackouts = blackouts ?? new List<int>();
-
-            if (_blackouts.Count > 0)
+        public LightsSwitch(int episodeLength, List<int> blackouts)
+        {
+            try
             {
-                foreach (var blackout in _blackouts)
+                if (episodeLength < 0)
                 {
-                    if (blackout < 0 || blackout >= _episodeLength)
-                        throw new ArgumentException("Blackout interval is invalid.");
+                    throw new ArgumentException("Episode length (timeLimit) cannot be negative.");
                 }
 
-                _blackouts.Sort();
+                _episodeLength = episodeLength;
+                _blackouts = blackouts ?? throw new ArgumentNullException(nameof(blackouts));
 
-                _blackoutsEnum =
-                    _blackouts[0] < 0
-                        ? new InfiniteEnumerator(-_blackouts[0])
-                        : _blackouts.GetEnumerator();
+                if (_blackouts.Count > 1)
+                {
+                    for (int i = 1; i < _blackouts.Count; i++)
+                    {
+                        if (_blackouts[i] <= _blackouts[i - 1])
+                        {
+                            throw new ArgumentException("Invalid blackout sequence: values must be in strictly increasing order.");
+                        }
+                    }
+                }
+
+                if (_blackouts.Count > 0 && _blackouts[0] < 0)
+                {
+                    _blackoutsEnum = new InfiniteEnumerator(-_blackouts[0]);
+                }
+                else
+                {
+                    _blackoutsEnum = _blackouts.GetEnumerator();
+                }
+                Reset();
             }
-            else
+            catch (Exception ex)
             {
-                _blackoutsEnum = _blackouts.GetEnumerator();
+                Console.WriteLine($"Error initialzisn lightswitch: {ex.Message}");
+                throw;
             }
-
-            Reset();
         }
 
         public void Reset()
         {
-            _lightStatus = true;
-            _blackoutsEnum.Reset();
-            _nextFrameSwitch = _blackoutsEnum.MoveNext() ? _blackoutsEnum.Current : -1;
+            try
+            {
+                _lightStatus = true;
+                _blackoutsEnum.Reset();
+                if (_blackoutsEnum.MoveNext())
+                {
+                    _nextFrameSwitch = _blackoutsEnum.Current;
+                }
+                else
+                {
+                    _nextFrameSwitch = -1;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error resetting LightsSwitch (blackouts): {ex.Message}");
+                throw;
+            }
         }
 
         public bool LightStatus(int step, int agentDecisionInterval)
         {
-            if (step < 0 || agentDecisionInterval <= 0)
-                throw new ArgumentException("Step and agent decision interval must be positive.");
-
-            if (step == _nextFrameSwitch * agentDecisionInterval)
+            try
             {
-                _lightStatus = !_lightStatus;
-                _nextFrameSwitch = _blackoutsEnum.MoveNext() ? _blackoutsEnum.Current : -1;
+                if (step == _nextFrameSwitch * agentDecisionInterval)
+                {
+                    _lightStatus = !_lightStatus;
+                    if (_blackoutsEnum.MoveNext())
+                    {
+                        _nextFrameSwitch = _blackoutsEnum.Current;
+                    }
+                }
+                return _lightStatus;
             }
-            return _lightStatus;
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error in LightStatus (blackouts): {ex.Message}");
+                return _lightStatus;
+            }
         }
     }
 }

--- a/Assets/Scripts/Lights.cs
+++ b/Assets/Scripts/Lights.cs
@@ -77,9 +77,21 @@ namespace Lights
                 }
             }
 
-            if (_blackouts.Count > 0 && _blackouts[0] < 0)
+            if (_blackouts.Count > 0)
             {
-                _blackoutsEnum = new InfiniteEnumerator(-_blackouts[0]);
+                if (_blackouts[_blackouts.Count - 1] > _episodeLength)
+                {
+                    throw new ArgumentException("Blackout time cannot exceed the episode length (timeLimit).", nameof(blackouts));
+                }
+
+                if (_blackouts[0] < 0)
+                {
+                    _blackoutsEnum = new InfiniteEnumerator(-_blackouts[0]);
+                }
+                else
+                {
+                    _blackoutsEnum = _blackouts.GetEnumerator();
+                }
             }
             else
             {

--- a/Assets/Scripts/Lights.cs
+++ b/Assets/Scripts/Lights.cs
@@ -91,7 +91,7 @@ namespace Lights
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error initialzisn lightswitch: {ex.Message}");
+                Console.WriteLine($"Error initialising lightSwitch: {ex.Message}");
                 throw;
             }
         }

--- a/Assets/Scripts/Lights.cs
+++ b/Assets/Scripts/Lights.cs
@@ -58,42 +58,35 @@ namespace Lights
 
         public LightsSwitch(int episodeLength, List<int> blackouts)
         {
-            try
+            if (episodeLength < 0)
             {
-                if (episodeLength < 0)
-                {
-                    throw new ArgumentException("Episode length (timeLimit) cannot be negative.");
-                }
+                throw new ArgumentException("Episode length (timeLimit) cannot be negative.", nameof(episodeLength));
+            }
 
-                _episodeLength = episodeLength;
-                _blackouts = blackouts ?? throw new ArgumentNullException(nameof(blackouts));
+            _episodeLength = episodeLength;
+            _blackouts = blackouts ?? throw new ArgumentNullException(nameof(blackouts));
 
-                if (_blackouts.Count > 1)
+            if (_blackouts.Count > 1)
+            {
+                for (int i = 1; i < _blackouts.Count; i++)
                 {
-                    for (int i = 1; i < _blackouts.Count; i++)
+                    if (_blackouts[i] <= _blackouts[i - 1])
                     {
-                        if (_blackouts[i] <= _blackouts[i - 1])
-                        {
-                            throw new ArgumentException("Invalid blackout sequence: values must be in strictly increasing order.");
-                        }
+                        throw new ArgumentException("Invalid blackout sequence: values must be in strictly increasing order.", nameof(blackouts));
                     }
                 }
+            }
 
-                if (_blackouts.Count > 0 && _blackouts[0] < 0)
-                {
-                    _blackoutsEnum = new InfiniteEnumerator(-_blackouts[0]);
-                }
-                else
-                {
-                    _blackoutsEnum = _blackouts.GetEnumerator();
-                }
-                Reset();
-            }
-            catch (Exception ex)
+            if (_blackouts.Count > 0 && _blackouts[0] < 0)
             {
-                Console.WriteLine($"Error initialising lightSwitch: {ex.Message}");
-                throw;
+                _blackoutsEnum = new InfiniteEnumerator(-_blackouts[0]);
             }
+            else
+            {
+                _blackoutsEnum = _blackouts.GetEnumerator();
+            }
+
+            Reset();
         }
 
         public void Reset()

--- a/Assets/Tests/EditMode/LightSwitchTests.cs
+++ b/Assets/Tests/EditMode/LightSwitchTests.cs
@@ -9,15 +9,17 @@ using Lights;
 public class LightsSwitchTests
 {
     [Test]
-    public void IncrementValueOnMoveNext()
+    public void InfiniteEnumerator_IncrementValueOnMoveNext()
     {
-        int initialValue = 3;
-        var enumerator = new InfiniteEnumerator(initialValue);
-
+        var enumerator = new InfiniteEnumerator(3);
         enumerator.MoveNext();
-        int currentValue = enumerator.Current;
+        Assert.AreEqual(3, enumerator.Current);
+    }
 
-        Assert.AreEqual(initialValue, currentValue);
+    [Test]
+    public void LightsSwitch_ThrowExceptionForNegativeEpisodeLength()
+    {
+        Assert.Throws<ArgumentException>(() => new LightsSwitch(-10, new List<int> { 1, 2, 3 }));
     }
 
     [Test]
@@ -34,61 +36,75 @@ public class LightsSwitchTests
     }
 
     [Test]
-    public void KeepIncrementingOnMultipleMoveNext()
+    public void InfiniteEnumerator_ResetToZero()
     {
-        int initialValue = 2;
-        var enumerator = new InfiniteEnumerator(initialValue);
-
+        var enumerator = new InfiniteEnumerator(5);
         enumerator.MoveNext();
-        Assert.AreEqual(2, enumerator.Current);
-
-        enumerator.MoveNext();
-        Assert.AreEqual(4, enumerator.Current);
-
-        enumerator.MoveNext();
-        Assert.AreEqual(6, enumerator.Current);
+        enumerator.Reset();
+        Assert.AreEqual(0, enumerator.Current);
     }
 
     [Test]
-    public void ThrowExceptionForNegativeEpisodeLength()
+    public void LightsSwitch_InitializeWithValidParameters()
     {
-        Assert.Throws<ArgumentException>(() => new LightsSwitch(-1, new List<int> { 1 }));
+        var lightsSwitch = new LightsSwitch(10, new List<int> { 1, 2, 3 });
+        Assert.DoesNotThrow(() => lightsSwitch.Reset());
     }
 
     [Test]
-    public void ThrowExceptionForInvalidBlackoutInterval()
+    public void LightsSwitch_HandleInfiniteBlackouts()
     {
-        Assert.Throws<ArgumentException>(() => new LightsSwitch(5, new List<int> { -1, 6 }));
+        var lightsSwitch = new LightsSwitch(10, new List<int> { -2 });
+        Assert.IsTrue(lightsSwitch.LightStatus(0, 1));
+        Assert.IsFalse(lightsSwitch.LightStatus(2, 1));
+        Assert.IsTrue(lightsSwitch.LightStatus(4, 1));
     }
 
     [Test]
-    public void ReturnTrueIfNoBlackouts()
+    public void LightsSwitch_ResetBehavior()
+    {
+        var lightsSwitch = new LightsSwitch(10, new List<int> { 1, 3 });
+        lightsSwitch.LightStatus(1, 1);
+        lightsSwitch.Reset();
+        Assert.IsTrue(lightsSwitch.LightStatus(0, 1));
+    }
+
+    [Test]
+    public void LightsSwitch_HandleEmptyBlackoutList()
     {
         var lightsSwitch = new LightsSwitch(10, new List<int>());
-
-        bool lightStatus = lightsSwitch.LightStatus(0, 1);
-
-        Assert.IsTrue(lightStatus);
-    }
-
-    [Test]
-    public void HandleMultipleBlackoutsProperly()
-    {
-        var blackouts = new List<int> { 1, 2, 3 };
-        var lightsSwitch = new LightsSwitch(10, blackouts);
-
         Assert.IsTrue(lightsSwitch.LightStatus(0, 1));
-        Assert.IsFalse(lightsSwitch.LightStatus(1, 1));
-        Assert.IsTrue(lightsSwitch.LightStatus(2, 1));
-        Assert.IsFalse(lightsSwitch.LightStatus(3, 1));
+        Assert.IsTrue(lightsSwitch.LightStatus(5, 1));
     }
 
     [Test]
-    public void ThrowExceptionForInvalidStepOrAgentDecisionInterval()
+    public void LightsSwitch_HandleDifferentAgentDecisionIntervals()
     {
-        var lightsSwitch = new LightsSwitch(10, new List<int> { 1 });
-
-        Assert.Throws<ArgumentException>(() => lightsSwitch.LightStatus(-1, 1));
-        Assert.Throws<ArgumentException>(() => lightsSwitch.LightStatus(1, 0));
+        var lightsSwitch = new LightsSwitch(20, new List<int> { 2, 4 });
+        Assert.IsTrue(lightsSwitch.LightStatus(0, 2));
+        Assert.IsFalse(lightsSwitch.LightStatus(4, 2));
+        Assert.IsTrue(lightsSwitch.LightStatus(8, 2));
     }
+
+    [Test]
+    public void LightsSwitch_ThrowExceptionForInvalidBlackoutSequence()
+    {
+        Assert.Throws<ArgumentException>(() => new LightsSwitch(20, new List<int> { 10, 1 }));
+    }
+
+    [Test]
+    public void LightsSwitch_HandleInfiniteBlackoutsWithNegativeNumber()
+    {
+        var lightsSwitch = new LightsSwitch(100, new List<int> { -20 });
+        Assert.IsTrue(lightsSwitch.LightStatus(0, 1));
+        Assert.IsTrue(lightsSwitch.LightStatus(19, 1));
+        Assert.IsFalse(lightsSwitch.LightStatus(20, 1));
+        Assert.IsFalse(lightsSwitch.LightStatus(39, 1));
+        Assert.IsTrue(lightsSwitch.LightStatus(40, 1));
+        Assert.IsTrue(lightsSwitch.LightStatus(59, 1));
+        Assert.IsFalse(lightsSwitch.LightStatus(60, 1));
+        Assert.IsFalse(lightsSwitch.LightStatus(79, 1));
+        Assert.IsTrue(lightsSwitch.LightStatus(80, 1));
+    }
+
 }

--- a/Assets/Tests/EditMode/LightSwitchTests.cs
+++ b/Assets/Tests/EditMode/LightSwitchTests.cs
@@ -95,16 +95,28 @@ public class LightsSwitchTests
     [Test]
     public void LightsSwitch_HandleInfiniteBlackoutsWithNegativeNumber()
     {
-        var lightsSwitch = new LightsSwitch(100, new List<int> { -20 });
-        Assert.IsTrue(lightsSwitch.LightStatus(0, 1));
-        Assert.IsTrue(lightsSwitch.LightStatus(19, 1));
-        Assert.IsFalse(lightsSwitch.LightStatus(20, 1));
-        Assert.IsFalse(lightsSwitch.LightStatus(39, 1));
-        Assert.IsTrue(lightsSwitch.LightStatus(40, 1));
-        Assert.IsTrue(lightsSwitch.LightStatus(59, 1));
-        Assert.IsFalse(lightsSwitch.LightStatus(60, 1));
-        Assert.IsFalse(lightsSwitch.LightStatus(79, 1));
-        Assert.IsTrue(lightsSwitch.LightStatus(80, 1));
-    }
+        /* 
+         * The blackout list contains a single negative number, which means that the blackout will go repeat infinitely on the blackoutInterval frame.
+         * The light should be OFF at step 0, ON at step 1, OFF at step 2, and so on.
+         */
+        const int episodeLength = 100;
+        const int blackoutInterval = 20;
+        const int agentDecisionInterval = 1;
 
+        var blackoutList = new List<int> { -blackoutInterval };
+        var lightsSwitch = new LightsSwitch(episodeLength, blackoutList);
+
+        /* Initial light status checks, then follows with the blackout sequences */
+        Assert.IsTrue(lightsSwitch.LightStatus(0, agentDecisionInterval), "Light should be ON at step 0");
+        Assert.IsTrue(lightsSwitch.LightStatus(19, agentDecisionInterval), "Light should be ON before blackout at step 19");
+
+        Assert.IsFalse(lightsSwitch.LightStatus(20, agentDecisionInterval), "Light should be OFF during blackout at step 20");
+        Assert.IsFalse(lightsSwitch.LightStatus(39, agentDecisionInterval), "Light should be OFF during blackout at step 39");
+
+        Assert.IsTrue(lightsSwitch.LightStatus(40, agentDecisionInterval), "Light should be ON after blackout at step 40");
+        Assert.IsTrue(lightsSwitch.LightStatus(59, agentDecisionInterval), "Light should be ON before next blackout at step 59");
+
+        Assert.IsFalse(lightsSwitch.LightStatus(60, agentDecisionInterval), "Light should be OFF during blackout at step 60");
+        Assert.IsFalse(lightsSwitch.LightStatus(79, agentDecisionInterval), "Light should be OFF during blackout at step 79");
+    }
 }


### PR DESCRIPTION
### PR Description

From AAI 3.1.3 upwards it seems the ability to use `blackouts` with `timeLimit = 0` is broken. 

### Specific Errors Produced:

- (**Primary) Invalid Blackout interval**: The case where episodeLength (timeLimit) == 0 results in an exception throw, specifically in `Lights.cs` here:
```
foreach (var blackout in _blackouts)
                {
                    if (blackout < 0 || blackout >= _episodeLength)
                        throw new ArgumentException("Blackout interval is invalid.");
                }
```
In the LightStatus method, the step is compared against _nextFrameSwitch * agentDecisionInterval. If agentDecisionInterval is 0 (which is possible if timeLimit is 0), it will result in a division by zero error. Furthermore, the error occurs because If _timeLimit_ is set to 0 and blackouts are specified (can be any value), it creates a contradiction. The blackouts are meant to occur at specific steps within the episode, but an episode with a timeLimit of 0 has no steps to begin with. 

The error propagates to a division by zero error further in the stack trace, as described below. 

- **(Secondary) Division by zero**: 
```
KeyNotFoundException: Tried to load arena 0 but it did not exist
AAI3EnvironmentManager.GetConfiguration (System.Int32 arenaID) (at Assets/Scripts/AAI3EnvironmentManager.cs:334)
TrainingArena.ResetArena () (at Assets/Scripts/TrainingArena.cs:143)
TrainingAgent.OnEpisodeBegin () (at Assets/Scripts/TrainingAgent.cs:753)
Unity.MLAgents.Agent._AgentReset () (at Library/PackageCache/com.unity.ml-agents@2.3.0-exp.3/Runtime/Agent.cs:1341)
Unity.MLAgents.Academy.ForcedFullReset () (at Library/PackageCache/com.unity.ml-agents@2.3.0-exp.3/Runtime/Academy.cs:567)
Unity.MLAgents.Academy.EnvironmentStep () (at Library/PackageCache/com.unity.ml-agents@2.3.0-exp.3/Runtime/Academy.cs:581)
Unity.MLAgents.AcademyFixedUpdateStepper.FixedUpdate () (at Library/PackageCache/com.unity.ml-agents@2.3.0-exp.3/Runtime/Academy.cs:43)

DivideByZeroException: Attempted to divide by zero.
TrainingArena.SetNextArenaID () (at Assets/Scripts/TrainingArena.cs:210)
TrainingArena.ResetArena () (at Assets/Scripts/TrainingArena.cs:141)
TrainingAgent.OnEpisodeBegin () (at Assets/Scripts/TrainingAgent.cs:753)
Unity.MLAgents.Agent._AgentReset () (at Library/PackageCache/com.unity.ml-agents@2.3.0-exp.3/Runtime/Agent.cs:1341)
Unity.MLAgents.Academy.ForcedFullReset () (at Library/PackageCache/com.unity.ml-agents@2.3.0-exp.3/Runtime/Academy.cs:567)
Unity.MLAgents.Academy.EnvironmentStep () (at Library/PackageCache/com.unity.ml-agents@2.3.0-exp.3/Runtime/Academy.cs:581)
Unity.MLAgents.AcademyFixedUpdateStepper.FixedUpdate () (at Library/PackageCache/com.unity.ml-agents@2.3.0-exp.3/Runtime/Academy.cs:43)
```

Indirectly, the division by zero is caused by the code in the LightStatus method - the condition step == _nextFrameSwitch * agentDecisionInterval can lead to a division by zero if agentDecisionInterval is zero (which was the case). Unity is simply unable to load the first arena into the arena configurations list as a result of the primary error.

### Proposed change(s)

This PR fixes the error, introduces more robust code, and more tests for `Lights.cs` script (blackouts feature).

The proposed PR code in the Lights.cs file handles the scenario where timeLimit is 0 and blackouts are used correctly. It allows for infinite blackout patterns using negative values in the blackout sequence, and the episodeLength (timeLimit) does not impact the blackout functionality.

It adds robust code to handle edge cases such as:
- Episode timeLimit is <0 (cannot be negative, must be >=0).
- Blackout sequence must be in increasing order (i.e. blackouts: [20, 25] and **NOT** blackouts: [20, 5]). This is because blackouts operates with intervals (from frame 20 to frame 25 in increasing direction). An opposite case would defeat the purpose of the implementation.
- Blackout values >0
- Blackout values <= episode length.

### Useful links (Github issues, discussion threads, etc.)

#42 

### Types of change(s)
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
    -  [See full list of unit tests in comments section below]
- [ ] Updated the changelog (if applicable)
- [x] Updated the documentation (animal-ai/docs/Arena-Environment-Guide/blackouts)
    - [Added more descriptive info on blackouts and limitations] 
- [ ] Updated the migration guide (if applicable)

### Other comments (if any)

**Tests:**
InfiniteEnumerator_IncrementValueOnMoveNext
Tests if the InfiniteEnumerator correctly increments the value when MoveNext() is called.
InfiniteEnumerator_ResetToZero

Tests if the InfiniteEnumerator resets to zero when Reset() is called.
LightsSwitch_InitializeWithValidParameters

Tests if the LightsSwitch can be initialized with valid parameters without throwing an exception.
LightsSwitch_HandleInfiniteBlackouts

Tests if the LightsSwitch correctly handles infinite blackouts.
LightsSwitch_ResetBehavior

Tests if the LightsSwitch resets its state correctly when Reset() is called.
LightsSwitch_HandleEmptyBlackoutList

Tests if the LightsSwitch handles an empty blackout list correctly.
LightsSwitch_HandleDifferentAgentDecisionIntervals

Tests if the LightsSwitch handles different agent decision intervals correctly.
LightsSwitch_ThrowExceptionForInvalidBlackoutSequence

Tests if the LightsSwitch throws an exception for an invalid blackout sequence.
LightsSwitch_HandleMultipleBlackouts

Tests if the LightsSwitch handles multiple blackouts correctly.
LightsSwitch_HandleInfiniteBlackoutsWithNegativeNumber

Tests if the LightsSwitch handles infinite blackouts with a negative number correctly.
LightsSwitch_ThrowExceptionForNegativeEpisodeLength

Tests if the LightsSwitch throws an exception for a negative episode length.

---

Yaml config example with error reproducible: 

```
!ArenaConfig
arenas:
  0: !Arena
    passMark: 2
    timeLimit: 0
    blackouts: [25, 60]
    items:
    - !Item
      name: Agent
      positions:
      - !Vector3 {x: 20, y: 1, z: 2}
      rotations: [0]
      frozenAgentDelays: [10]
    - !Item
      name: Wall
      positions:
      - !Vector3 {x: 20, y: 0, z: 10}
      - !Vector3 {x: 20, y: .5, z: 2.5}
      - !Vector3 {x: 30, y: 0, z: 30}
      - !Vector3 {x: 5, y: 0, z: 38}
      - !Vector3 {x: 35, y: 0, z: 38}
      - !Vector3 {x: 20, y: 0, z: 38}
      - !Vector3 {x: 20, y: 0, z: 39.9}
      rotations: [0,0,0,0,0,45,0]
      colors:
      - !RGB {r: 0, g: 0, b: 255}
      - !RGB {r: 0, g: 0, b: 255}
      - !RGB {r: -1, g: -1, b: -1} #color parameter
      - !RGB {r: 0, g: 0, b: 255}
      - !RGB {r: 0, g: 0, b: 255} 
      - !RGB {r: 222, g: 0, b: 0}
      - !RGB {r: 222, g: 0, b: 0}
      sizes:
      - !Vector3 {x: 2, y: .5, z: 19.5}
      - !Vector3 {x: 2, y: .5, z: 5}
      - !Vector3 {x: 10, y: 0.5, z: 1}
      - !Vector3 {x: 1, y: .5, z: 2}
      - !Vector3 {x: 1, y: .5, z: 2}
      - !Vector3 {x: 2, y: 2, z: 2}
      - !Vector3 {x: 10, y: 2, z: 0.1}
```

### Screenshots (if any)
