### PR TITLE
Switch config loading

### DIFF
--- a/Assets/Scripts/ArenasParametersSideChannel.cs
+++ b/Assets/Scripts/ArenasParametersSideChannel.cs
@@ -26,7 +26,7 @@ public class ArenasParametersSideChannel : SideChannel
         // Check if the received string is a valid file path
         if (!string.IsNullOrEmpty(potentialFilePath) && File.Exists(potentialFilePath))
         {
-            // New behavior: read arena config from file
+            // read arena config from file
             byte[] yamlData = ReadArenaConfigFile(potentialFilePath);
             if (yamlData != null)
             {
@@ -36,7 +36,7 @@ public class ArenasParametersSideChannel : SideChannel
         }
         else
         {
-            // Original behavior: treat raw data as arena content directly
+            // treat raw data as arena content directly
             ArenasParametersEventArgs args = new ArenasParametersEventArgs { arenas_yaml = rawData, };
             OnArenasParametersReceived(args);
         }

--- a/Assets/Scripts/ArenasParametersSideChannel.cs
+++ b/Assets/Scripts/ArenasParametersSideChannel.cs
@@ -20,13 +20,24 @@ public class ArenasParametersSideChannel : SideChannel
 
     protected override void OnMessageReceived(IncomingMessage msg)
     {
-        string filePath = Encoding.UTF8.GetString(msg.GetRawBytes());
+        byte[] rawData = msg.GetRawBytes();
+        string potentialFilePath = Encoding.UTF8.GetString(rawData);
 
-        byte[] yamlData = ReadArenaConfigFile(filePath);
-        if (yamlData != null)
+        // Check if the received string is a valid file path
+        if (!string.IsNullOrEmpty(potentialFilePath) && File.Exists(potentialFilePath))
         {
-            /* Create the event args and the YAML data */
-            ArenasParametersEventArgs args = new ArenasParametersEventArgs { arenas_yaml = yamlData, };
+            // New behavior: read arena config from file
+            byte[] yamlData = ReadArenaConfigFile(potentialFilePath);
+            if (yamlData != null)
+            {
+                ArenasParametersEventArgs args = new ArenasParametersEventArgs { arenas_yaml = yamlData, };
+                OnArenasParametersReceived(args);
+            }
+        }
+        else
+        {
+            // Original behavior: treat raw data as arena content directly
+            ArenasParametersEventArgs args = new ArenasParametersEventArgs { arenas_yaml = rawData, };
             OnArenasParametersReceived(args);
         }
     }

--- a/Assets/Scripts/ArenasParametersSideChannel.cs
+++ b/Assets/Scripts/ArenasParametersSideChannel.cs
@@ -22,6 +22,7 @@ public class ArenasParametersSideChannel : SideChannel
     {
         byte[] rawData = msg.GetRawBytes();
         string potentialFilePath = Encoding.UTF8.GetString(rawData);
+        ArenasParametersEventArgs args = null;
 
         // Check if the received string is a valid file path
         if (!string.IsNullOrEmpty(potentialFilePath) && File.Exists(potentialFilePath))
@@ -30,16 +31,19 @@ public class ArenasParametersSideChannel : SideChannel
             byte[] yamlData = ReadArenaConfigFile(potentialFilePath);
             if (yamlData != null)
             {
-                ArenasParametersEventArgs args = new ArenasParametersEventArgs { arenas_yaml = yamlData, };
-                OnArenasParametersReceived(args);
+                args = new ArenasParametersEventArgs { arenas_yaml = yamlData, };
+            }
+            else
+            {
+                Debug.LogError($"Failed to read arena config from file: {potentialFilePath}");
             }
         }
         else
         {
             // treat raw data as arena content directly
-            ArenasParametersEventArgs args = new ArenasParametersEventArgs { arenas_yaml = rawData, };
-            OnArenasParametersReceived(args);
+            args = new ArenasParametersEventArgs { arenas_yaml = rawData, };
         }
+        OnArenasParametersReceived(args);
     }
 
     private byte[] ReadArenaConfigFile(string filePath)


### PR DESCRIPTION
### PR Description

Large config files can take a long time for animal ai to load due to the entire content of the file beign transfered via the side channel. This change adds support for the unity side to load the config given a file path rather than the content of the file. It only does this if the string is a valid file path.

### Proposed change(s)

Modifies the on message received function to check if the string is a valid file path and if so tries to load it. Otherwise it defaults to the original behaviour.

### Useful links (Github issues, discussion threads, etc.)

PR for the python side.
https://github.com/Kinds-of-Intelligence-CFI/animal-ai-python/pull/16

### Types of change(s)
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
  - [ ] Passed all e2e tests
- [ ] Updated project build version (if applicable)
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments (if any)
I will also create another PR for the python side and link it here.

### Screenshots (if any)
